### PR TITLE
feat: core utilities, RouterAgent & spec‑compliant QuoteAgent stub

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,8 +1,8 @@
 """Agent namespace \u2013 concrete agents will be added incrementally."""
 
-from importlib import metadata
-
 __all__ = ["BaseAgent", "QuoteAgent"]
+
+# NOTE: public re-export kept above in patch.
 
 
 class BaseAgent:  # minimal base so subclasses compile
@@ -18,10 +18,37 @@ class QuoteAgent(BaseAgent):
     name = "quote"
 
     def run(self, prompt: str, **kwargs):  # noqa: D401,ANN001
-        """Temporary stub \u2013 returns a placeholder until SpecGuard & pricing arrive."""
+        """Produce a *format-compliant* placeholder quote.
+
+        Very naive parsing: look for "<number> windows in <Suburb>" and charge $10/ea.
+        """
+
+        import re
+        from datetime import datetime
+
+        match = re.search(r"(\d+)\s+windows?\s+in\s+([A-Za-z]+)", prompt, flags=re.I)
+        if match:
+            qty = int(match.group(1))
+            suburb = match.group(2).title()
+        else:
+            qty, suburb = 1, "Unknown"
+
+        total = qty * 10.0
+        year = datetime.utcnow().year
+
+        quote_line = f"> \${total:,.2f} for cleaning {qty} windows in {suburb}"
+        attribution = f"> \u2014 QuoteGPT, {year}"
+        rationale = (
+            "Rationale: placeholder $10/window rate while pricing engine is pending."
+        )
+
+        full_quote = "\n".join([quote_line, attribution, "", rationale])
 
         return {
-            "quote_text": "> $0.00 \u2013 Placeholder quote",  # SpecGuard\u2011compliant shape
-            "rationale": "QuoteAgent stub; replace with real logic.",
+            "quote_text": full_quote,
+            "rationale": rationale,
+            "suburb": suburb,
+            "quantity": qty,
+            "total": total,
         }
 

--- a/backend/agents/router_agent.py
+++ b/backend/agents/router_agent.py
@@ -1,0 +1,14 @@
+"""Extremely simple router – will grow as more agents arrive."""
+
+from backend.agents import QuoteAgent
+
+
+class RouterAgent:  # noqa: D401 – No BaseAgent yet (router isn’t an LLM)
+    """Dispatch prompt to the correct agent."""
+
+    @staticmethod
+    def dispatch(prompt: str):  # noqa: ANN001 – broad for now
+        lowercase = prompt.lower()
+        if "quote" in lowercase or "clean" in lowercase:
+            return QuoteAgent().run(prompt)
+        return {"error": "Unrecognised task"}

--- a/backend/api/root.py
+++ b/backend/api/root.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter
 
+from backend.agents.router_agent import RouterAgent
+
 
 router = APIRouter()
 
@@ -9,4 +11,15 @@ async def healthcheck() -> dict[str, str]:
     """Simple liveness probe used by CI and Docker compose."""
 
     return {"status": "ok"}
+
+
+# -------- Quote endpoint ---------------------------------------------------
+
+
+@router.post("/quote", tags=["quote"])
+async def generate_quote(request: dict[str, str]):  # noqa: ANN001 – minimal
+    """Accept `{ "prompt": "…" }` and return QuoteAgent JSON output."""
+
+    prompt: str = request.get("prompt", "")
+    return RouterAgent.dispatch(prompt)
 

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,0 +1,13 @@
+"""Core utilities (LLM provider, prompt manager, SpecGuard stub)."""
+
+from pathlib import Path
+
+import yaml
+
+CONFIG_PATH = Path(__file__).parent.parent.parent / "config.yaml"
+
+
+def load_config() -> dict:  # noqa: ANN001 – simple helper
+    if CONFIG_PATH.exists():
+        return yaml.safe_load(CONFIG_PATH.read_text()) or {}
+    return {}

--- a/backend/core/llm_provider.py
+++ b/backend/core/llm_provider.py
@@ -1,0 +1,13 @@
+"""Wrapper around external or local LLMs.
+
+Only a stub for now – returns a canned response so QuoteAgent can compile.
+The real implementation will call OpenAI or Ollama based on `config.yaml`.
+"""
+
+from __future__ import annotations
+
+
+def chat(prompt: str) -> str:  # noqa: D401,ANN001 – trunkated interface
+    """Return a dummy LLM completion (for early tests)."""
+
+    return f"LLM‑stub echo: {prompt}"

--- a/backend/core/prompt_manager.py
+++ b/backend/core/prompt_manager.py
@@ -1,0 +1,7 @@
+"""Central place to assemble prompts once LLM integration lands."""
+
+
+def build_quote_prompt(raw: str, context: str | None = None) -> str:
+    if context:
+        return f"Context:\n{context}\n\nUser: {raw}"
+    return raw

--- a/backend/core/spec_guard.py
+++ b/backend/core/spec_guard.py
@@ -1,0 +1,17 @@
+"""Minimal SpecGuard so tests can assert a pass/fail score."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SpecResult:
+    score: float
+    violations: list[str]
+
+
+def grade(response: str) -> SpecResult:  # noqa: D401,ANN001
+    """Very relaxed grader – 1.0 if response starts with ">", else 0.0."""
+
+    if response.lstrip().startswith(">"):
+        return SpecResult(score=1.0, violations=[])
+    return SpecResult(score=0.0, violations=["missing blockquote"])

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+# Initial configuration – will expand.
+
+llm:
+  provider: "openai"  # or "ollama"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "8000:8000"
     volumes:
       - ..:/app
+      - ../config.yaml:/app/config.yaml:ro
     environment:
       - PYTHONUNBUFFERED=1
 

--- a/tests/test_quote_basic.py
+++ b/tests/test_quote_basic.py
@@ -1,0 +1,13 @@
+from backend import create_app
+
+from fastapi.testclient import TestClient
+
+
+def test_quote_endpoint_blockquote():
+    client = TestClient(create_app())
+    resp = client.post("/quote", json={"prompt": "Clean 2 windows in Perth"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["quote_text"].startswith(">")  # Spec minimal
+    assert "Perth" in body["quote_text"]
+    assert "$20.00" in body["quote_text"]


### PR DESCRIPTION
## Summary
- add `backend/core` utils with config loading, llm stub, prompt manager, and minimal SpecGuard
- create `RouterAgent` and expand `QuoteAgent` with simple quoting logic
- expose `/quote` endpoint to dispatch prompts
- mount `config.yaml` in docker and include basic configuration
- add tests for quote endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ad31d1408326a5d04192d395e38d