### PR TITLE
feat: CustomerAgent, customer table & /customer endpoint

### DIFF
--- a/backend/agents/customer_agent.py
+++ b/backend/agents/customer_agent.py
@@ -1,0 +1,57 @@
+"""CustomerAgent – create / update CRM records (local DB for now)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from backend.database import Customer, get_session
+
+
+class CustomerAgent:  # noqa: D401 – not an LLM
+    name = "customer"
+
+    @staticmethod
+    def run(payload: dict[str, Any]):  # noqa: D401,ANN001 – generic input
+        """Create or update a customer.
+
+        *Upsert* strategy keyed by `email` (required).
+        Returns full customer record as dict.
+        """
+
+        email = payload.get("email")
+        if not email:
+            return {"error": "email is required"}
+
+        with get_session() as sess:
+            obj: Customer | None = (
+                sess.query(Customer)
+                .filter(Customer.email == email)
+                .one_or_none()  # noqa: E501
+            )
+
+            if obj is None:
+                obj = Customer(
+                    email=email,
+                    name=payload.get("name", "Unnamed"),
+                )
+                sess.add(obj)
+
+            # update mutable fields
+            obj.name = payload.get("name", obj.name)
+            obj.phone = payload.get("phone", obj.phone)
+            obj.suburb = payload.get("suburb", obj.suburb)
+            if tags := payload.get("tags"):
+                obj.tags = json.dumps(tags)
+
+            sess.commit()
+
+            return {
+                "id": obj.id,
+                "name": obj.name,
+                "email": obj.email,
+                "phone": obj.phone,
+                "suburb": obj.suburb,
+                "tags": json.loads(obj.tags) if obj.tags else [],
+                "created_at": obj.created_at.isoformat(),
+            }

--- a/backend/agents/router_agent.py
+++ b/backend/agents/router_agent.py
@@ -1,6 +1,7 @@
 """Extremely simple router – will grow as more agents arrive."""
 
 from backend.agents import QuoteAgent
+from backend.agents.customer_agent import CustomerAgent  # noqa: F401
 
 
 class RouterAgent:  # noqa: D401 – No BaseAgent yet (router isn’t an LLM)
@@ -11,4 +12,9 @@ class RouterAgent:  # noqa: D401 – No BaseAgent yet (router isn’t an LLM)
         lowercase = prompt.lower()
         if "quote" in lowercase or "clean" in lowercase:
             return QuoteAgent().run(prompt)
+        if "customer" in lowercase or "contact" in lowercase:
+            # naive – expects payload handled by API
+            return {
+                "error": "Customer task requires JSON payload via /customer",
+            }
         return {"error": "Unrecognised task"}

--- a/backend/api/root.py
+++ b/backend/api/root.py
@@ -1,15 +1,21 @@
 from fastapi import APIRouter
+
+from backend.agents.customer_agent import CustomerAgent
 from backend.agents.router_agent import RouterAgent
-from backend.database import Quote, get_session  # placed here to avoid circular import earlier
+from backend.database import (  # placed here to avoid circular import earlier
+    Quote, get_session)
 
 router = APIRouter()
+
 
 @router.get("/health", tags=["meta"])
 async def healthcheck() -> dict[str, str]:
     """Simple liveness probe used by CI and Docker compose."""
     return {"status": "ok"}
 
+
 # -------- Quote endpoint ---------------------------------------------------
+
 
 @router.post("/quote", tags=["quote"])
 async def generate_quote(request: dict[str, str]):  # noqa: ANN001 – minimal
@@ -17,7 +23,9 @@ async def generate_quote(request: dict[str, str]):  # noqa: ANN001 – minimal
     prompt: str = request.get("prompt", "")
     return RouterAgent.dispatch(prompt)
 
+
 # -------- Quote retrieval --------------------------------------------------
+
 
 @router.get("/quote/{quote_id}", tags=["quote"])
 async def fetch_quote(quote_id: str):
@@ -35,3 +43,16 @@ async def fetch_quote(quote_id: str):
             "total": obj.total,
             "created_at": obj.created_at.isoformat(),
         }
+
+
+# -------- Customer CRUD ----------------------------------------------------
+
+
+@router.post("/customer", tags=["customer"])
+async def upsert_customer(body: dict):  # noqa: ANN001
+    """Create or update a customer record.
+
+    Body must include at least `email`.
+    """
+
+    return CustomerAgent.run(body)

--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -3,19 +3,24 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
-from slugify import slugify
 from sqlalchemy import DateTime, Float, String, create_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
-from datetime import datetime, timezone
+from sqlalchemy.types import Text
 
 # ---------------------------------------------------------------------------
 # Engine & Base
 # ---------------------------------------------------------------------------
 
-DATA_DIR = Path(os.getenv("DATA_DIR", Path(__file__).resolve().parent.parent.parent / "data"))
+DATA_DIR = Path(
+    os.getenv(
+        "DATA_DIR",
+        Path(__file__).resolve().parent.parent.parent / "data",
+    )
+)
 DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 db_file = DATA_DIR / "app.db"
@@ -25,28 +30,57 @@ engine = create_engine(f"sqlite:///{db_file}", echo=False, future=True)
 class Base(DeclarativeBase):
     pass
 
+
 # ---------------------------------------------------------------------------
-# Models – only Quote for now.  Customer & Job will come in later PRs.
+# Models – Quote and Customer for now. Job will come in later PRs.
 # ---------------------------------------------------------------------------
+
 
 class Quote(Base):
     __tablename__ = "quotes"
 
-    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
+    id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid4())
+    )
     prompt: Mapped[str] = mapped_column(String, nullable=False)
     quote_text: Mapped[str] = mapped_column(String, nullable=False)
     rationale: Mapped[str] = mapped_column(String, nullable=False)
     suburb: Mapped[str] = mapped_column(String, nullable=True)
     total: Mapped[float] = mapped_column(Float, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Customer model (basic)
+# ---------------------------------------------------------------------------
+
+
+class Customer(Base):
+    __tablename__ = "customers"
+
+    id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid4())
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    email: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    phone: Mapped[str] = mapped_column(String, nullable=True)
+    suburb: Mapped[str] = mapped_column(String, nullable=True)
+    tags: Mapped[str] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
 
 
 # ---------------------------------------------------------------------------
 # Session helper
 # ---------------------------------------------------------------------------
 
+
 def get_session() -> Session:  # noqa: D401,ANN001 – convenience factory
     return Session(engine, autoflush=False, expire_on_commit=False)
+
 
 # Create tables at import time (simple for SQLite dev flow)
 Base.metadata.create_all(engine)

--- a/poetry.lock
+++ b/poetry.lock
@@ -714,6 +714,21 @@ pygments = ">=2.7.2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -807,6 +822,18 @@ files = [
     {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
     {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
     {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]
@@ -1254,4 +1281,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "fc1dd5d7c1640412be27a465128d223756579a0756febc61e961b65a2c00cc1a"
+content-hash = "9cdc59484c6cabe814ab61d1be7ed1c1351f4960803dff63577cb69a365e8159"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ click = "^8.1.7"
 httpx = "^0.27.0"
 SQLAlchemy = "^2.0.30"
 python-slugify = "^8.0.4"  # tiny helper for DB path default
+python-dateutil = "^2.9.0.post0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"

--- a/tests/test_customer_agent.py
+++ b/tests/test_customer_agent.py
@@ -1,0 +1,23 @@
+from backend.agents.customer_agent import CustomerAgent
+
+
+def test_customer_create_update():
+    create = CustomerAgent.run(
+        {
+            "name": "Alice Example",
+            "email": "alice@example.com",
+            "phone": "0400 000 000",
+            "suburb": "Fremantle",
+            "tags": ["VIP"],
+        }
+    )
+
+    assert create["name"] == "Alice Example"
+    assert create["suburb"] == "Fremantle"
+
+    # update suburb only
+    update = CustomerAgent.run(
+        {"email": "alice@example.com", "suburb": "Palmyra"}
+    )  # noqa: E501
+    assert update["suburb"] == "Palmyra"
+    assert update["name"] == "Alice Example"  # unchanged


### PR DESCRIPTION
- add Customer model and persistence utilities
- implement CustomerAgent with upsert behaviour
- expose `/customer` POST endpoint
- router dispatch recognizes customer tasks
- unit tests cover create/update

Some pre-commit hooks failed (black/isort loop and mypy type stubs) but tests pass.


------
https://chatgpt.com/codex/tasks/task_e_6887c57ae52c8326a402ed0cc31e7ebd