### PR TITLE
Add SPDX license headers

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Backend package root for 925\u00a0Stack\u00a0AI."""
 
 __all__ = [

--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Agent namespace \u2013 concrete agents will be added incrementally."""
 
 

--- a/backend/agents/customer_agent.py
+++ b/backend/agents/customer_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 
 from typing import Any
 

--- a/backend/agents/job_agent.py
+++ b/backend/agents/job_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 
 
 from backend.database import Customer, Job, Quote, get_session

--- a/backend/agents/memory_agent.py
+++ b/backend/agents/memory_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Simple memory lookup for past quotes via the database."""
 
 from __future__ import annotations

--- a/backend/agents/router_agent.py
+++ b/backend/agents/router_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Extremely simple router – will grow as more agents arrive."""
 
 from backend.agents import QuoteAgent

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: MIT
 """API package grouping all FastAPI routers."""

--- a/backend/api/root.py
+++ b/backend/api/root.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from fastapi import APIRouter
 
 from backend.agents.customer_agent import CustomerAgent

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """CLI entry\u2011point wrapping the Router/Agents for local usage."""
 
 import json

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Core utilities (LLM provider, prompt manager, SpecGuard stub)."""
 
 from pathlib import Path

--- a/backend/core/llm_provider.py
+++ b/backend/core/llm_provider.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Unified LLM interface with **fallback order**: GPT-4 -> Ollama -> stub.
 
 * Reads provider + model from `config.yaml` (loaded by ``core.load_config``).

--- a/backend/core/prompt_manager.py
+++ b/backend/core/prompt_manager.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Central place to assemble prompts once LLM integration lands."""
 
 

--- a/backend/core/spec_guard.py
+++ b/backend/core/spec_guard.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Lightweight markdown rule checker for QuoteAgent outputs."""
 
 from __future__ import annotations

--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 
 
 """SQLite persistence layer (SQLAlchemy 2.0 ORM)."""

--- a/backend/integrations/__init__.py
+++ b/backend/integrations/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: MIT
 """External service wrappers (Stripe, Xero, HubSpot …)."""

--- a/backend/integrations/stripe_service.py
+++ b/backend/integrations/stripe_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Minimal Stripe helper – safe to import without real API keys.
 
 In **CI / dev** it falls back to a deterministic stub so tests don’t reach the network.

--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Centralised JSON logger (tiny – will be expanded with file/telemetry sinks)."""
 
 import json

--- a/tests/test_customer_agent.py
+++ b/tests/test_customer_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from backend.agents.customer_agent import CustomerAgent
 
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from fastapi.testclient import TestClient
 
 from backend import create_app

--- a/tests/test_job_agent.py
+++ b/tests/test_job_agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from backend.agents.customer_agent import CustomerAgent
 from backend.agents.job_agent import JobAgent
 from backend.agents.quote_agent import QuoteAgent

--- a/tests/test_job_invoice.py
+++ b/tests/test_job_invoice.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Ensure JobAgent auto-creates invoice id when marked completed."""
 
 import importlib

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import builtins
 from importlib import reload
 

--- a/tests/test_memory_injection.py
+++ b/tests/test_memory_injection.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Verify `vector_used=True` when a prior similar quote exists."""
 
 from backend.agents.quote_agent import QuoteAgent

--- a/tests/test_quote_basic.py
+++ b/tests/test_quote_basic.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from backend import create_app
 
 from fastapi.testclient import TestClient

--- a/tests/test_quote_persistence.py
+++ b/tests/test_quote_persistence.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from backend import create_app
 
 from fastapi.testclient import TestClient

--- a/tests/test_specguard.py
+++ b/tests/test_specguard.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from backend.core.spec_guard import grade
 
 


### PR DESCRIPTION
## Summary
- add SPDX license headers to the source and test modules

## Testing
- `poetry run pytest -q` *(fails: NoReferencedTableError)*

------
https://chatgpt.com/codex/tasks/task_e_6887dccc58908326a109bdb8bd912b86