### PR TITLE
Implement QuoteAgent wrapper and restore basic agents

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,86 +1,23 @@
-"""Agent namespace \u2013 concrete agents will be added incrementally."""
+"""Agent namespace with minimal implementations used in tests."""
+
+from __future__ import annotations
+
+from typing import Any
 
 
-
-# NOTE: public re-export kept above in patch.
-
-
-class BaseAgent:  # minimal base so subclasses compile
-    """Skeleton for all agents. Real logic comes in later PRs."""
+class BaseAgent:
+    """Skeleton base class for all agents."""
 
     name: str = "base"
 
-    def run(self, prompt: str, **kwargs):  # noqa: ANN001 \u2013 narrow later
+    def run(self, prompt: str, **kwargs: Any) -> Any:  # noqa: ANN401
         raise NotImplementedError
 
 
-class QuoteAgent(BaseAgent):
-    name = "quote"
+from .quote_agent import QuoteAgent
+from .customer_agent import CustomerAgent
+from .job_agent import JobAgent
 
-    def run(self, prompt: str, **kwargs):
-        """Produce a *format-compliant* placeholder quote.
+__all__ = ["BaseAgent", "QuoteAgent", "CustomerAgent", "JobAgent"]
 
-        Very naive parsing: look for "<number> windows in <Suburb>"
-        and charge $10/ea.
-        """
-        import re
-        from datetime import datetime, timezone
-
-        match = re.search(
-            r"(\d+)\s+windows?\s+in\s+([A-Za-z]+)",
-            prompt,
-            flags=re.I,
-        )
-        if match:
-            qty = int(match.group(1))
-            suburb = match.group(2).title()
-        else:
-            qty, suburb = 1, "Unknown"
-
-        total = qty * 10.0
-        year = datetime.utcnow().year
-
-
-        attribution = f"> — QuoteGPT, {year}"
-        rationale = "Rationale: This is a placeholder rationale for the quote."
-
-        full_quote = "\n".join([quote_line, attribution, "", rationale])
-
-        # -------- SpecGuard -------------------------------------------------
-        from backend.core.spec_guard import grade
-
-        spec_result = grade(full_quote)
-
-        result = {
-            "quote_text": full_quote,
-            "rationale": rationale,
-            "suburb": suburb,
-            "quantity": qty,
-            "total": total,
-            "compliance": {
-                "score": spec_result.score,
-                "violations": spec_result.violations,
-            },
-            "vector_used": bool(relevant_snippets),
-        }
-
-        # -------- Persistence ----------------------------------------------
-
-
-        with get_session() as sess:
-            obj = Quote(
-                prompt=prompt,
-                quote_text=full_quote,
-                rationale=rationale,
-                suburb=suburb,
-                total=total,
-            )
-            sess.add(obj)
-            sess.commit()
-            result["quote_id"] = obj.id
-
-        return result
-
-
-from .customer_agent import CustomerAgent  # noqa: E402
 

--- a/backend/agents/customer_agent.py
+++ b/backend/agents/customer_agent.py
@@ -1,6 +1,32 @@
+from __future__ import annotations
 
 from typing import Any
+from uuid import uuid4
 
 from backend.database import Customer, get_session
 
 
+class CustomerAgent:
+    """Create or update customer records."""
+
+    @staticmethod
+    def run(payload: dict[str, Any]) -> dict[str, Any]:  # noqa: D401,ANN401
+        email = payload["email"]
+        with get_session() as sess:
+            cust = sess.query(Customer).filter_by(email=email).first()
+            if cust is None:
+                cust = Customer(id=str(uuid4()), email=email, name=payload.get("name"))
+                sess.add(cust)
+            else:
+                if payload.get("name"):
+                    cust.name = payload["name"]
+            sess.commit()
+            name = cust.name
+            cust_id = cust.id
+        suburb = payload.get("suburb")
+        return {
+            "id": cust_id,
+            "email": email,
+            "name": name,
+            "suburb": suburb,
+        }

--- a/backend/agents/job_agent.py
+++ b/backend/agents/job_agent.py
@@ -1,14 +1,54 @@
+from __future__ import annotations
 
+from datetime import datetime, timezone
+from typing import Any
 
 from backend.database import Customer, Job, Quote, get_session
+from backend.integrations import stripe_service
 
 
+class JobAgent:
+    """Create or update cleaning jobs."""
 
-                job: Job | None = sess.get(Job, job_id)
+    @staticmethod
+    def run(payload: dict[str, Any]) -> dict[str, Any]:  # noqa: D401,ANN401
+        job_id = payload.get("job_id")
+        with get_session() as sess:
+            if job_id:
+                job = sess.get(Job, job_id)
                 if job is None:
                     return {"error": "job not found", "id": job_id}
-
                 if payload.get("status"):
                     job.status = payload["status"]
+                    if job.status == "completed" and job.invoice_id is None:
+                        customer = sess.get(Customer, job.customer_id)
+                        quote = sess.get(Quote, job.quote_id)
+                        if customer and quote:
+                            job.invoice_id = stripe_service.create_invoice(
+                                customer.email,
+                                int(quote.total * 100),
+                            )
                 if payload.get("scheduled_date"):
-
+                    job.scheduled_date = datetime.now(timezone.utc)
+                sess.commit()
+            else:
+                job = Job(
+                    customer_id=payload["customer_id"],
+                    quote_id=payload["quote_id"],
+                    scheduled_date=datetime.now(timezone.utc)
+                    if payload.get("scheduled_date")
+                    else None,
+                )
+                sess.add(job)
+                sess.commit()
+            result = {
+                "id": job.id,
+                "customer_id": job.customer_id,
+                "quote_id": job.quote_id,
+                "status": job.status,
+                "scheduled_date": job.scheduled_date.isoformat()
+                if job.scheduled_date
+                else None,
+                "invoice_id": job.invoice_id,
+            }
+        return result

--- a/backend/agents/quote_agent.py
+++ b/backend/agents/quote_agent.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from backend.core.spec_guard import grade
+from backend.database import Quote, get_session
+
+
+class QuoteAgent:
+    """Generate simple window cleaning quotes."""
+
+    name = "quote"
+    PRICE_PER_WINDOW = 10.0
+
+    def run(self, prompt: str, **_: Any) -> dict[str, Any]:  # noqa: D401,ANN401
+        match = re.search(r"(\d+)\s+windows?\s+in\s+([A-Za-z]+)", prompt, flags=re.I)
+        if match:
+            qty = int(match.group(1))
+            suburb = match.group(2).title()
+        else:
+            qty, suburb = 1, "Unknown"
+
+        total = qty * self.PRICE_PER_WINDOW
+        quote_line = f"> ${total:.2f} to clean {qty} windows in {suburb}"
+        year = datetime.now(timezone.utc).year
+        attribution = f"> — QuoteGPT, {year}"
+        rationale = "Rationale: This is a placeholder rationale for the quote."
+        full_quote = "\n".join([quote_line, attribution, "", rationale])
+
+        # naive memory lookup for similar quotes
+        with get_session() as sess:
+            prior = (
+                sess.query(Quote)
+                .filter(Quote.suburb == suburb, Quote.total == total)
+                .first()
+            )
+        vector_used = prior is not None
+
+        spec_result = grade(full_quote)
+
+        with get_session() as sess:
+            obj = Quote(
+                prompt=prompt,
+                quote_text=full_quote,
+                rationale=rationale,
+                suburb=suburb,
+                total=total,
+            )
+            sess.add(obj)
+            sess.commit()
+            quote_id = obj.id
+
+        return {
+            "quote_text": full_quote,
+            "rationale": rationale,
+            "suburb": suburb,
+            "quantity": qty,
+            "total": total,
+            "compliance": {
+                "score": spec_result.score,
+                "violations": spec_result.violations,
+            },
+            "vector_used": vector_used,
+            "quote_id": quote_id,
+        }

--- a/backend/agents/router_agent.py
+++ b/backend/agents/router_agent.py
@@ -1,6 +1,6 @@
 """Extremely simple router – will grow as more agents arrive."""
 
-from backend.agents import QuoteAgent
+from backend.agents.quote_agent import QuoteAgent
 
 
 
@@ -12,6 +12,5 @@ class RouterAgent:  # noqa: D401 – No BaseAgent yet (router isn’t an LLM)
         lowercase = prompt.lower()
         if "quote" in lowercase or "clean" in lowercase:
             return QuoteAgent().run(prompt)
-        if "customer" in lowercase or "contact" in lowercase:
 
         return {"error": "Unrecognised task"}

--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -1,18 +1,11 @@
-
-
-"""SQLite persistence layer (SQLAlchemy 2.0 ORM)."""
 from __future__ import annotations
-from sqlalchemy import (
-    create_engine, String, Float, DateTime, ForeignKey
-)
-from sqlalchemy.orm import (
-    DeclarativeBase, mapped_column, Mapped, relationship, Session
-)
 
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
+
+from sqlalchemy import DateTime, Float, ForeignKey, String, create_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship
 
 # ---------------------------------------------------------------------------
 # Engine & Base
@@ -24,8 +17,10 @@ DATA_DIR.mkdir(parents=True, exist_ok=True)
 db_file = DATA_DIR / "app.db"
 engine = create_engine(f"sqlite:///{db_file}", echo=False, future=True)
 
+
 class Base(DeclarativeBase):
     pass
+
 
 # ---------------------------------------------------------------------------
 # Customer model
@@ -40,72 +35,37 @@ class Customer(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
 
-
 # ---------------------------------------------------------------------------
-# Engine & Base
-# ---------------------------------------------------------------------------
-
-DATA_DIR = Path(
-
-)
-DATA_DIR.mkdir(parents=True, exist_ok=True)
-
-db_file = DATA_DIR / "app.db"
-engine = create_engine(f"sqlite:///{db_file}", echo=False, future=True)
-
-
-class Base(DeclarativeBase):
-    pass
-
-
+# Quote model
 # ---------------------------------------------------------------------------
 
 class Quote(Base):
     __tablename__ = "quotes"
 
-    id: Mapped[str] = mapped_column(
-        String, primary_key=True, default=lambda: str(uuid4())
-    )
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     prompt: Mapped[str] = mapped_column(String, nullable=False)
     quote_text: Mapped[str] = mapped_column(String, nullable=False)
     rationale: Mapped[str] = mapped_column(String, nullable=False)
-    suburb: Mapped[str] = mapped_column(String, nullable=True)
+    suburb: Mapped[str | None] = mapped_column(String, nullable=True)
     total: Mapped[float] = mapped_column(Float, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
-    )
-
-
-# ---------------------------------------------------------------------------
-
-
-    id: Mapped[str] = mapped_column(
-        String, primary_key=True, default=lambda: str(uuid4())
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
 
 # ---------------------------------------------------------------------------
 # Job model (links Quote and Customer)
 # ---------------------------------------------------------------------------
 
-
 class Job(Base):
     __tablename__ = "jobs"
 
-    id: Mapped[str] = mapped_column(
-        String, primary_key=True, default=lambda: str(uuid4())
-    )
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid4()))
     customer_id: Mapped[str] = mapped_column(ForeignKey("customers.id"))
     quote_id: Mapped[str] = mapped_column(ForeignKey("quotes.id"))
     status: Mapped[str] = mapped_column(String, default="draft")
-    scheduled_date: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    scheduled_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     notes: Mapped[str | None] = mapped_column(String, nullable=True)
     invoice_id: Mapped[str | None] = mapped_column(String, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     customer = relationship("Customer")
     quote = relationship("Quote")
@@ -115,8 +75,7 @@ class Job(Base):
 # Session helper
 # ---------------------------------------------------------------------------
 
-
-def get_session() -> Session:  # noqa: D401,ANN001 – convenience factory
+def get_session() -> Session:  # noqa: D401,ANN001
     return Session(engine, autoflush=False, expire_on_commit=False)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2490,6 +2490,18 @@ tests = ["autopep8", "isort", "llnl-hatchet", "numpy", "pytest", "pytest-forked"
 tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250516"
+description = "Typing stubs for PyYAML"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_pyyaml-6.0.12.20250516-py3-none-any.whl", hash = "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530"},
+    {file = "types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.14.1"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -2814,4 +2826,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "047bd13800bd5ae2c0705388483da34ec0fa543f96a40f276947288642575438"
+content-hash = "5e051c4c335f29876641741c15dde0f0d1d9dcdff663401a75d52ffcf906ade5"


### PR DESCRIPTION
## Summary
- rebuild agent namespace and new QuoteAgent wrapper
- add minimal CustomerAgent and JobAgent implementations
- simplify RouterAgent dispatch logic
- clean up and rebuild SQLAlchemy models
- update lockfile for tests

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887dccc58908326a109bdb8bd912b86